### PR TITLE
Fix reuse of remediation effort info across lines

### DIFF
--- a/OWASP.py
+++ b/OWASP.py
@@ -34,6 +34,7 @@ def generate_result_json():
                     if current_method:
                         line += f" ({current_method.strip()})"
                     current_result["line"] = line.strip()  # 使用.strip()來去除多餘的空格
+                    current_method = None
 
 
             elif cell in danger_keywords:


### PR DESCRIPTION
## Summary
- avoid applying a previous remediation effort to unrelated findings

## Testing
- `python3 -m py_compile OWASP.py DW.py PDF.py toexcel.py`


------
https://chatgpt.com/codex/tasks/task_e_6852193f7ec4832c93762af9b59587dd